### PR TITLE
Refactor newtype Mod

### DIFF
--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
@@ -29,9 +30,12 @@ module Data.Mod
   , (^%)
   ) where
 
+import Control.DeepSeq
+import Data.Euclidean (GcdDomain(..), Euclidean(..), Field)
 import Data.Ratio
 import Data.Semiring (Semiring(..), Ring(..))
 import GHC.Exts
+import GHC.Generics
 import GHC.Integer.GMP.Internals
 import GHC.Natural (Natural(..), powModNatural)
 
@@ -68,7 +72,9 @@ someNatVal n = case TL.someNatVal (toInteger n) of
 --
 -- Note that modulo cannot be negative.
 newtype Mod (m :: Nat) = Mod Natural
-  deriving (Eq, Ord, Enum)
+  deriving (Eq, Ord, Enum, Generic)
+
+instance NFData (Mod m)
 
 instance KnownNat m => Show (Mod m) where
   show m = "(" ++ show (getVal m) ++ " `modulo` " ++ show (getMod m) ++ ")"

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -19,6 +19,7 @@
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE UnboxedTuples              #-}
 
 module Data.Mod
@@ -75,12 +76,25 @@ newtype Mod (m :: Nat) = Mod
   -- ^ The canonical representative of the residue class,
   -- always between 0 and m-1 inclusively.
   }
-  deriving (Eq, Ord, Enum, Generic)
+  deriving (Eq, Ord, Generic)
 
 instance NFData (Mod m)
 
 instance KnownNat m => Show (Mod m) where
   show m = "(" ++ show (unMod m) ++ " `modulo` " ++ show (natVal m) ++ ")"
+
+instance KnownNat m => Enum (Mod m) where
+  succ x = if x == maxBound then throw Overflow  else coerce (succ @Natural) x
+  pred x = if x == minBound then throw Underflow else coerce (pred @Natural) x
+
+  toEnum   = fromIntegral
+  fromEnum = fromIntegral . unMod
+
+  enumFrom x       = enumFromTo x maxBound
+  enumFromThen x y = enumFromThenTo x y (if y >= x then maxBound else minBound)
+
+  enumFromTo     = coerce (enumFromTo     @Natural)
+  enumFromThenTo = coerce (enumFromThenTo @Natural)
 
 instance KnownNat m => Bounded (Mod m) where
   minBound = Mod 0

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -21,12 +21,9 @@
 {-# LANGUAGE UnboxedTuples              #-}
 
 module Data.Mod
-  ( -- * Known modulo
-    Mod
+  ( Mod
   , getVal
   , getNatVal
-  , getMod
-  , getNatMod
   , invertMod
   , powMod
   , (^%)

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -4,23 +4,19 @@
 -- Licence:     MIT
 -- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
 --
--- Modular arithmetic with modulo on type level.
+-- <https://en.wikipedia.org/wiki/Modular_arithmetic Modular arithmetic>
+-- with modulo on type level.
 --
 
-{-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE MagicHash                  #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE UnboxedTuples              #-}
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE KindSignatures   #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE MagicHash        #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UnboxedTuples    #-}
 
 module Data.Mod
   ( Mod

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -114,7 +114,7 @@ instance KnownNat m => Num (Mod m) where
                   else NatJ# r#
 
   mx@(Mod !x) * (Mod !y) =
-    Mod $ x * y `rem` getNatMod mx
+    Mod $ x * y `Prelude.rem` getNatMod mx
     -- `rem` is slightly faster than `mod`
   {-# INLINE (*) #-}
 
@@ -160,6 +160,26 @@ instance KnownNat m => Fractional (Mod m) where
     Nothing -> throw DivideByZero
     Just y  -> y
   {-# INLINE recip #-}
+
+-- | Division by residue, which is not coprime with the modulo,
+-- will throw 'DivideByZero'. Consider using 'invertMod' for non-prime moduli.
+instance KnownNat m => GcdDomain (Mod m) where
+  divide x y = Just (x / y)
+  gcd        = const $ const 1
+  lcm        = const $ const 1
+  coprime    = const $ const True
+
+-- | Division by residue, which is not coprime with the modulo,
+-- will throw 'DivideByZero'. Consider using 'invertMod' for non-prime moduli.
+instance KnownNat m => Euclidean (Mod m) where
+  degree      = const 0
+  quotRem x y = (x / y, 0)
+  quot        = (/)
+  rem         = const $ const 0
+
+-- | Division by residue, which is not coprime with the modulo,
+-- will throw 'DivideByZero'. Consider using 'invertMod' for non-prime moduli.
+instance KnownNat m => Field (Mod m)
 
 -- | Linking type and value levels: extract modulo @m@ as a value.
 getMod :: KnownNat m => Mod m -> Integer

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -30,6 +30,7 @@ module Data.Mod
   ) where
 
 import Data.Ratio
+import Data.Semiring (Semiring(..), Ring(..))
 import GHC.Exts
 import GHC.Integer.GMP.Internals
 import GHC.Natural (Natural(..), powModNatural)
@@ -118,6 +119,26 @@ instance KnownNat m => Num (Mod m) where
     where
       mx = Mod $ fromInteger $ x `mod` getMod mx
   {-# INLINE fromInteger #-}
+
+instance KnownNat m => Semiring (Mod m) where
+  plus  = (+)
+  {-# INLINE plus #-}
+  times = (*)
+  {-# INLINE times #-}
+  zero  = Mod 0
+  {-# INLINE zero #-}
+  one   = mx
+    where
+      mx = if getNatMod mx > 1 then Mod 1 else Mod 0
+  {-# INLINE one #-}
+  fromNatural x = mx
+    where
+      mx = Mod $ x `mod` getNatMod mx
+  {-# INLINE fromNatural #-}
+
+instance KnownNat m => Ring (Mod m) where
+  negate = Prelude.negate
+  {-# INLINE negate #-}
 
 -- | Beware that division by residue, which is not coprime with the modulo,
 -- will result in runtime error. Consider using 'invertMod' instead.

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -1,0 +1,188 @@
+-- |
+-- Module:      Data.Mod
+-- Copyright:   (c) 2017-2019 Andrew Lelechenko
+-- Licence:     MIT
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+--
+-- Safe modular arithmetic with modulo on type level.
+--
+
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MagicHash                  #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE UnboxedTuples              #-}
+
+module Data.Mod
+  ( -- * Known modulo
+    Mod
+  , getVal
+  , getNatVal
+  , getMod
+  , getNatMod
+  , invertMod
+  , powMod
+  , (^%)
+  ) where
+
+import Data.Ratio
+import GHC.Exts
+import GHC.Integer.GMP.Internals
+import GHC.Natural (Natural(..), powModNatural)
+import GHC.TypeNats.Compat
+
+-- | Wrapper for residues modulo @m@.
+--
+-- @Mod 3 :: Mod 10@ stands for the class of integers, congruent to 3 modulo 10 (…−17, −7, 3, 13, 23…).
+-- The modulo is stored on type level, so it is impossible, for example, to add up by mistake
+-- residues with different moduli.
+--
+-- >>> :set -XDataKinds
+-- >>> (3 :: Mod 10) + (4 :: Mod 12)
+-- error: Couldn't match type ‘12’ with ‘10’...
+-- >>> (3 :: Mod 10) + 8
+-- (1 `modulo` 10)
+--
+-- Note that modulo cannot be negative.
+newtype Mod (m :: Nat) = Mod Natural
+  deriving (Eq, Ord, Enum)
+
+instance KnownNat m => Show (Mod m) where
+  show m = "(" ++ show (getVal m) ++ " `modulo` " ++ show (getMod m) ++ ")"
+
+instance KnownNat m => Bounded (Mod m) where
+  minBound = Mod 0
+  maxBound = let mx = Mod (getNatMod mx - 1) in mx
+
+instance KnownNat m => Num (Mod m) where
+  mx@(Mod x) + Mod y =
+    Mod $ if xy >= m then xy - m else xy
+    where
+      xy = x + y
+      m = getNatMod mx
+  {-# INLINE (+) #-}
+  mx@(Mod x) - Mod y =
+    Mod $ if x >= y then x - y else m + x - y
+    where
+      m = getNatMod mx
+  {-# INLINE (-) #-}
+  negate mx@(Mod x) =
+    Mod $ if x == 0 then 0 else getNatMod mx - x
+  {-# INLINE negate #-}
+
+  -- If modulo is small and fits into one machine word,
+  -- there is no need to use long arithmetic at all
+  -- and we can save some allocations.
+  mx@(Mod (NatS# x#)) * (Mod (NatS# y#)) = case getNatMod mx of
+    NatS# m# -> let !(# z1#, z2# #) = timesWord2# x# y# in
+                let !(# _, r# #) = quotRemWord2# z1# z2# m# in
+                Mod (NatS# r#)
+    NatJ# b# -> let !(# z1#, z2# #) = timesWord2# x# y# in
+                let r# = wordToBigNat2 z1# z2# `remBigNat` b# in
+                Mod $ if isTrue# (sizeofBigNat# r# ==# 1#)
+                  then NatS# (bigNatToWord r#)
+                  else NatJ# r#
+
+  mx@(Mod !x) * (Mod !y) =
+    Mod $ x * y `rem` getNatMod mx
+    -- `rem` is slightly faster than `mod`
+  {-# INLINE (*) #-}
+
+  abs = id
+  {-# INLINE abs #-}
+  signum = const $ Mod 1
+  {-# INLINE signum #-}
+  fromInteger x = mx
+    where
+      mx = Mod $ fromInteger $ x `mod` getMod mx
+  {-# INLINE fromInteger #-}
+
+-- | Beware that division by residue, which is not coprime with the modulo,
+-- will result in runtime error. Consider using 'invertMod' instead.
+instance KnownNat m => Fractional (Mod m) where
+  fromRational r = case denominator r of
+    1   -> num
+    den -> num / fromInteger den
+    where
+      num = fromInteger (numerator r)
+  {-# INLINE fromRational #-}
+  recip mx = case invertMod mx of
+    Nothing -> error $ "recip{Mod}: residue is not coprime with modulo"
+    Just y  -> y
+  {-# INLINE recip #-}
+
+-- | Linking type and value levels: extract modulo @m@ as a value.
+getMod :: KnownNat m => Mod m -> Integer
+getMod = toInteger . natVal
+{-# INLINE getMod #-}
+
+-- | Linking type and value levels: extract modulo @m@ as a value.
+getNatMod :: KnownNat m => Mod m -> Natural
+getNatMod = natVal
+{-# INLINE getNatMod #-}
+
+-- | The canonical representative of the residue class, always between 0 and @m-1@ inclusively.
+getVal :: Mod m -> Integer
+getVal (Mod x) = toInteger x
+{-# INLINE getVal #-}
+
+-- | The canonical representative of the residue class, always between 0 and @m-1@ inclusively.
+getNatVal :: Mod m -> Natural
+getNatVal (Mod x) = x
+{-# INLINE getNatVal #-}
+
+-- | Computes the modular inverse, if the residue is coprime with the modulo.
+--
+-- >>> :set -XDataKinds
+-- >>> invertMod (3 :: Mod 10)
+-- Just (7 `modulo` 10) -- because 3 * 7 = 1 :: Mod 10
+-- >>> invertMod (4 :: Mod 10)
+-- Nothing
+invertMod :: KnownNat m => Mod m -> Maybe (Mod m)
+invertMod mx
+  = if y <= 0
+    then Nothing
+    else Just $ Mod $ fromInteger y
+  where
+    -- first argument of recipModInteger is guaranteed to be positive
+    y = recipModInteger (getVal mx) (getMod mx)
+{-# INLINABLE invertMod #-}
+
+-- | Drop-in replacement for 'Prelude.^', with much better performance.
+--
+-- >>> :set -XDataKinds
+-- >>> powMod (3 :: Mod 10) 4
+-- (1 `modulo` 10)
+powMod :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
+powMod mx a
+  | a < 0     = error $ "^{Mod}: negative exponent"
+  | otherwise = Mod $ powModNatural (getNatVal mx) (fromIntegral a) (getNatMod mx)
+{-# INLINABLE [1] powMod #-}
+
+{-# SPECIALISE [1] powMod ::
+  KnownNat m => Mod m -> Integer -> Mod m,
+  KnownNat m => Mod m -> Natural -> Mod m,
+  KnownNat m => Mod m -> Int     -> Mod m,
+  KnownNat m => Mod m -> Word    -> Mod m #-}
+
+{-# RULES
+"powMod/2/Integer"     forall x. powMod x (2 :: Integer) = let u = x in u*u
+"powMod/3/Integer"     forall x. powMod x (3 :: Integer) = let u = x in u*u*u
+"powMod/2/Int"         forall x. powMod x (2 :: Int)     = let u = x in u*u
+"powMod/3/Int"         forall x. powMod x (3 :: Int)     = let u = x in u*u*u
+"powMod/2/Word"        forall x. powMod x (2 :: Word)    = let u = x in u*u
+"powMod/3/Word"        forall x. powMod x (3 :: Word)    = let u = x in u*u*u
+#-}
+
+-- | Infix synonym of 'powMod'.
+(^%) :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
+(^%) = powMod
+{-# INLINE (^%) #-}
+
+infixr 8 ^%

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -23,8 +23,7 @@
 
 module Data.Mod
   ( Mod
-  , getVal
-  , getNatVal
+  , unMod
   , invertMod
   , (^%)
   ) where
@@ -71,7 +70,11 @@ someNatVal n = case TL.someNatVal (toInteger n) of
 -- (1 `modulo` 10)
 --
 -- Note that modulo cannot be negative.
-newtype Mod (m :: Nat) = Mod Natural
+newtype Mod (m :: Nat) = Mod
+  { unMod :: Natural
+  -- ^ The canonical representative of the residue class,
+  -- always between 0 and m-1 inclusively.
+  }
   deriving (Eq, Ord, Enum, Generic)
 
 instance NFData (Mod m)

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -26,7 +26,6 @@ module Data.Mod
   , getVal
   , getNatVal
   , invertMod
-  , powMod
   , (^%)
   ) where
 
@@ -221,32 +220,27 @@ invertMod mx
 -- | Drop-in replacement for 'Prelude.^', with much better performance.
 --
 -- >>> :set -XDataKinds
--- >>> powMod (3 :: Mod 10) 4
+-- >>> (3 :: Mod 10) ^% 4
 -- (1 `modulo` 10)
-powMod :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
-powMod mx a
+(^%) :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
+mx ^% a
   | a < 0     = error $ "^{Mod}: negative exponent"
   | otherwise = Mod $ powModNatural (getNatVal mx) (fromIntegral a) (getNatMod mx)
-{-# INLINABLE [1] powMod #-}
+{-# INLINABLE [1] (^%) #-}
 
-{-# SPECIALISE [1] powMod ::
+{-# SPECIALISE [1] (^%) ::
   KnownNat m => Mod m -> Integer -> Mod m,
   KnownNat m => Mod m -> Natural -> Mod m,
   KnownNat m => Mod m -> Int     -> Mod m,
   KnownNat m => Mod m -> Word    -> Mod m #-}
 
 {-# RULES
-"powMod/2/Integer"     forall x. powMod x (2 :: Integer) = let u = x in u*u
-"powMod/3/Integer"     forall x. powMod x (3 :: Integer) = let u = x in u*u*u
-"powMod/2/Int"         forall x. powMod x (2 :: Int)     = let u = x in u*u
-"powMod/3/Int"         forall x. powMod x (3 :: Int)     = let u = x in u*u*u
-"powMod/2/Word"        forall x. powMod x (2 :: Word)    = let u = x in u*u
-"powMod/3/Word"        forall x. powMod x (3 :: Word)    = let u = x in u*u*u
+"powMod/2/Integer"     forall x. x ^% (2 :: Integer) = let u = x in u*u
+"powMod/3/Integer"     forall x. x ^% (3 :: Integer) = let u = x in u*u*u
+"powMod/2/Int"         forall x. x ^% (2 :: Int)     = let u = x in u*u
+"powMod/3/Int"         forall x. x ^% (3 :: Int)     = let u = x in u*u*u
+"powMod/2/Word"        forall x. x ^% (2 :: Word)    = let u = x in u*u
+"powMod/3/Word"        forall x. x ^% (3 :: Word)    = let u = x in u*u*u
 #-}
-
--- | Infix synonym of 'powMod'.
-(^%) :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
-(^%) = powMod
-{-# INLINE (^%) #-}
 
 infixr 8 ^%

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -207,8 +207,10 @@ invertMod mx
 -- (1 `modulo` 10)
 (^%) :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
 mx ^% a
-  | a < 0     = error $ "^{Mod}: negative exponent"
-  | otherwise = Mod $ powModNatural (unMod mx) (fromIntegral a) (natVal mx)
+  | a < 0     = case invertMod mx of
+    Nothing ->  throw DivideByZero
+    Just my ->  Mod $ powModNatural (unMod my) (fromIntegral (-a)) (natVal mx)
+  | otherwise = Mod $ powModNatural (unMod mx) (fromIntegral a)    (natVal mx)
 {-# INLINABLE [1] (^%) #-}
 
 {-# SPECIALISE [1] (^%) ::
@@ -218,6 +220,8 @@ mx ^% a
   KnownNat m => Mod m -> Word    -> Mod m #-}
 
 {-# RULES
+"powMod"               forall (x :: KnownNat m => Mod m) p. x ^ p = x ^% p
+
 "powMod/2/Integer"     forall x. x ^% (2 :: Integer) = let u = x in u*u
 "powMod/3/Integer"     forall x. x ^% (3 :: Integer) = let u = x in u*u*u
 "powMod/2/Int"         forall x. x ^% (2 :: Int)     = let u = x in u*u

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -8,6 +8,7 @@
 --
 
 {-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -35,7 +36,25 @@ import Data.Ratio
 import GHC.Exts
 import GHC.Integer.GMP.Internals
 import GHC.Natural (Natural(..), powModNatural)
-import GHC.TypeNats.Compat
+
+#if MIN_VERSION_base(4,11,0)
+import GHC.TypeNats hiding (Mod)
+#elif MIN_VERSION_base(4,10,0)
+import GHC.TypeNats
+#else
+
+import GHC.TypeLits hiding (natVal, someNatVal)
+import qualified GHC.TypeLits as TL
+
+natVal :: KnownNat n => proxy n -> Natural
+natVal = fromInteger . TL.natVal
+
+someNatVal :: Natural -> SomeNat
+someNatVal n = case TL.someNatVal (toInteger n) of
+  Nothing -> error "someNatVal: impossible negative argument"
+  Just sn -> sn
+
+#endif
 
 -- | Wrapper for residues modulo @m@.
 --

--- a/Data/Mod.hs
+++ b/Data/Mod.hs
@@ -30,6 +30,7 @@ module Data.Mod
   , (^%)
   ) where
 
+import Control.Exception
 import Control.DeepSeq
 import Data.Euclidean (GcdDomain(..), Euclidean(..), Field)
 import Data.Ratio
@@ -146,8 +147,8 @@ instance KnownNat m => Ring (Mod m) where
   negate = Prelude.negate
   {-# INLINE negate #-}
 
--- | Beware that division by residue, which is not coprime with the modulo,
--- will result in runtime error. Consider using 'invertMod' instead.
+-- | Division by residue, which is not coprime with the modulo,
+-- will throw 'DivideByZero'. Consider using 'invertMod' for non-prime moduli.
 instance KnownNat m => Fractional (Mod m) where
   fromRational r = case denominator r of
     1   -> num
@@ -156,7 +157,7 @@ instance KnownNat m => Fractional (Mod m) where
       num = fromInteger (numerator r)
   {-# INLINE fromRational #-}
   recip mx = case invertMod mx of
-    Nothing -> error $ "recip{Mod}: residue is not coprime with modulo"
+    Nothing -> throw DivideByZero
     Just y  -> y
   {-# INLINE recip #-}
 

--- a/Math/NumberTheory/Moduli/Chinese.hs
+++ b/Math/NumberTheory/Moduli/Chinese.hs
@@ -41,7 +41,7 @@ import Data.Ratio
 import Data.Semiring (Semiring(..), (^), Ring, minus)
 import GHC.TypeNats.Compat
 
-import Math.NumberTheory.Moduli.Class
+import Math.NumberTheory.Moduli.Class (SomeMod(..), modulo, Mod, getVal, invertMod)
 import Math.NumberTheory.Euclidean.Coprimes
 import Math.NumberTheory.Utils (recipMod, splitOff)
 
@@ -121,8 +121,8 @@ chineseWrap
 chineseWrap f g (SomeMod n1) (SomeMod n2)
   = fmap (`modulo` fromInteger (f m1 m2)) (g (getVal n1, m1) (getVal n2, m2))
   where
-    m1 = getMod n1
-    m2 = getMod n2
+    m1 = toInteger $ natVal n1
+    m2 = toInteger $ natVal n2
 chineseWrap _ _ (SomeMod n) (InfMod r)
   | isCompatible n r = Just $ InfMod r
   | otherwise        = Nothing

--- a/Math/NumberTheory/Moduli/Class.hs
+++ b/Math/NumberTheory/Moduli/Class.hs
@@ -60,6 +60,16 @@ getNatMod :: KnownNat m => Mod m -> Natural
 getNatMod = natVal
 {-# INLINE getNatMod #-}
 
+-- | The canonical representative of the residue class, always between 0 and m-1 inclusively.
+getVal :: Mod m -> Integer
+getVal = toInteger . unMod
+{-# INLINE getVal #-}
+
+-- | The canonical representative of the residue class, always between 0 and m-1 inclusively.
+getNatVal :: Mod m -> Natural
+getNatVal = unMod
+{-# INLINE getNatVal #-}
+
 -- | Synonym of '(^%)'.
 powMod :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
 powMod = (^%)

--- a/Math/NumberTheory/Moduli/Class.hs
+++ b/Math/NumberTheory/Moduli/Class.hs
@@ -60,6 +60,11 @@ getNatMod :: KnownNat m => Mod m -> Natural
 getNatMod = natVal
 {-# INLINE getNatMod #-}
 
+-- | Synonym of '(^%)'.
+powMod :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
+powMod = (^%)
+{-# INLINE powMod #-}
+
 -- | This type represents elements of the multiplicative group mod m, i.e.
 -- those elements which are coprime to m. Use @toMultElement@ to construct.
 newtype MultMod m = MultMod {
@@ -69,7 +74,7 @@ newtype MultMod m = MultMod {
 instance KnownNat m => Semigroup (MultMod m) where
   MultMod a <> MultMod b = MultMod (a * b)
   stimes k a@(MultMod a')
-    | k >= 0 = MultMod (powMod a' k)
+    | k >= 0 = MultMod (a' ^% k)
     | otherwise = invertGroup $ stimes (-k) a
   -- ^ This Semigroup is in fact a group, so @stimes@ can be called with a negative first argument.
 

--- a/Math/NumberTheory/Moduli/Class.hs
+++ b/Math/NumberTheory/Moduli/Class.hs
@@ -43,168 +43,12 @@ module Math.NumberTheory.Moduli.Class
   , KnownNat
   ) where
 
+import Data.Mod
 import Data.Proxy
-import Data.Ratio
 import Data.Semigroup
 import Data.Type.Equality
-import GHC.Exts
-import GHC.Integer.GMP.Internals
-import GHC.Natural (Natural(..), powModNatural)
+import GHC.Natural (Natural(..))
 import GHC.TypeNats.Compat
-
--- | Wrapper for residues modulo @m@.
---
--- @Mod 3 :: Mod 10@ stands for the class of integers, congruent to 3 modulo 10 (…−17, −7, 3, 13, 23…).
--- The modulo is stored on type level, so it is impossible, for example, to add up by mistake
--- residues with different moduli.
---
--- >>> :set -XDataKinds
--- >>> (3 :: Mod 10) + (4 :: Mod 12)
--- error: Couldn't match type ‘12’ with ‘10’...
--- >>> (3 :: Mod 10) + 8
--- (1 `modulo` 10)
---
--- Note that modulo cannot be negative.
-newtype Mod (m :: Nat) = Mod Natural
-  deriving (Eq, Ord, Enum)
-
-instance KnownNat m => Show (Mod m) where
-  show m = "(" ++ show (getVal m) ++ " `modulo` " ++ show (getMod m) ++ ")"
-
-instance KnownNat m => Bounded (Mod m) where
-  minBound = Mod 0
-  maxBound = let mx = Mod (getNatMod mx - 1) in mx
-
-instance KnownNat m => Num (Mod m) where
-  mx@(Mod x) + Mod y =
-    Mod $ if xy >= m then xy - m else xy
-    where
-      xy = x + y
-      m = getNatMod mx
-  {-# INLINE (+) #-}
-  mx@(Mod x) - Mod y =
-    Mod $ if x >= y then x - y else m + x - y
-    where
-      m = getNatMod mx
-  {-# INLINE (-) #-}
-  negate mx@(Mod x) =
-    Mod $ if x == 0 then 0 else getNatMod mx - x
-  {-# INLINE negate #-}
-
-  -- If modulo is small and fits into one machine word,
-  -- there is no need to use long arithmetic at all
-  -- and we can save some allocations.
-  mx@(Mod (NatS# x#)) * (Mod (NatS# y#)) = case getNatMod mx of
-    NatS# m# -> let !(# z1#, z2# #) = timesWord2# x# y# in
-                let !(# _, r# #) = quotRemWord2# z1# z2# m# in
-                Mod (NatS# r#)
-    NatJ# b# -> let !(# z1#, z2# #) = timesWord2# x# y# in
-                let r# = wordToBigNat2 z1# z2# `remBigNat` b# in
-                Mod $ if isTrue# (sizeofBigNat# r# ==# 1#)
-                  then NatS# (bigNatToWord r#)
-                  else NatJ# r#
-
-  mx@(Mod !x) * (Mod !y) =
-    Mod $ x * y `rem` getNatMod mx
-    -- `rem` is slightly faster than `mod`
-  {-# INLINE (*) #-}
-
-  abs = id
-  {-# INLINE abs #-}
-  signum = const $ Mod 1
-  {-# INLINE signum #-}
-  fromInteger x = mx
-    where
-      mx = Mod $ fromInteger $ x `mod` getMod mx
-  {-# INLINE fromInteger #-}
-
--- | Beware that division by residue, which is not coprime with the modulo,
--- will result in runtime error. Consider using 'invertMod' instead.
-instance KnownNat m => Fractional (Mod m) where
-  fromRational r = case denominator r of
-    1   -> num
-    den -> num / fromInteger den
-    where
-      num = fromInteger (numerator r)
-  {-# INLINE fromRational #-}
-  recip mx = case invertMod mx of
-    Nothing -> error $ "recip{Mod}: residue is not coprime with modulo"
-    Just y  -> y
-  {-# INLINE recip #-}
-
--- | Linking type and value levels: extract modulo @m@ as a value.
-getMod :: KnownNat m => Mod m -> Integer
-getMod = toInteger . natVal
-{-# INLINE getMod #-}
-
--- | Linking type and value levels: extract modulo @m@ as a value.
-getNatMod :: KnownNat m => Mod m -> Natural
-getNatMod = natVal
-{-# INLINE getNatMod #-}
-
--- | The canonical representative of the residue class, always between 0 and @m-1@ inclusively.
-getVal :: Mod m -> Integer
-getVal (Mod x) = toInteger x
-{-# INLINE getVal #-}
-
--- | The canonical representative of the residue class, always between 0 and @m-1@ inclusively.
-getNatVal :: Mod m -> Natural
-getNatVal (Mod x) = x
-{-# INLINE getNatVal #-}
-
--- | Computes the modular inverse, if the residue is coprime with the modulo.
---
--- >>> :set -XDataKinds
--- >>> invertMod (3 :: Mod 10)
--- Just (7 `modulo` 10) -- because 3 * 7 = 1 :: Mod 10
--- >>> invertMod (4 :: Mod 10)
--- Nothing
-invertMod :: KnownNat m => Mod m -> Maybe (Mod m)
-invertMod mx
-  = if y <= 0
-    then Nothing
-    else Just $ Mod $ fromInteger y
-  where
-    -- first argument of recipModInteger is guaranteed to be positive
-    y = recipModInteger (getVal mx) (getMod mx)
-{-# INLINABLE invertMod #-}
-
--- | Drop-in replacement for 'Prelude.^', with much better performance.
---
--- >>> :set -XDataKinds
--- >>> powMod (3 :: Mod 10) 4
--- (1 `modulo` 10)
-powMod :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
-powMod mx a
-  | a < 0     = error $ "^{Mod}: negative exponent"
-  | otherwise = Mod $ powModNatural (getNatVal mx) (fromIntegral a) (getNatMod mx)
-{-# INLINABLE [1] powMod #-}
-
-{-# SPECIALISE [1] powMod ::
-  KnownNat m => Mod m -> Integer -> Mod m,
-  KnownNat m => Mod m -> Natural -> Mod m,
-  KnownNat m => Mod m -> Int     -> Mod m,
-  KnownNat m => Mod m -> Word    -> Mod m #-}
-
-{-# RULES
-"powMod/2/Integer"     forall x. powMod x (2 :: Integer) = let u = x in u*u
-"powMod/3/Integer"     forall x. powMod x (3 :: Integer) = let u = x in u*u*u
-"powMod/2/Int"         forall x. powMod x (2 :: Int)     = let u = x in u*u
-"powMod/3/Int"         forall x. powMod x (3 :: Int)     = let u = x in u*u*u
-"powMod/2/Word"        forall x. powMod x (2 :: Word)    = let u = x in u*u
-"powMod/3/Word"        forall x. powMod x (3 :: Word)    = let u = x in u*u*u
-#-}
-
--- | Infix synonym of 'powMod'.
-(^%) :: (KnownNat m, Integral a) => Mod m -> a -> Mod m
-(^%) = powMod
-{-# INLINE (^%) #-}
-
-infixr 8 ^%
-
--- Unfortunately, such rule never fires due to technical details
--- of type classes in Core.
--- {-# RULES "^%Mod" forall (x :: KnownNat m => Mod m) p. x ^ p = x ^% p #-}
 
 -- | This type represents elements of the multiplicative group mod m, i.e.
 -- those elements which are coprime to m. Use @toMultElement@ to construct.
@@ -306,9 +150,12 @@ liftBinOpMod
   -> Mod m
   -> Mod n
   -> SomeMod
-liftBinOpMod f mx@(Mod x) my@(Mod y) = case someNatVal m of
-  SomeNat (_ :: Proxy t) -> SomeMod (Mod (x `mod` m) `f` Mod (y `mod` m) :: Mod t)
+liftBinOpMod f mx my = case someNatVal m of
+  SomeNat (_ :: Proxy t) ->
+    SomeMod (fromIntegral (x `mod` m) `f` fromIntegral (y `mod` m) :: Mod t)
   where
+    x = getNatVal mx
+    y = getNatVal my
     m = natVal mx `gcd` natVal my
 
 liftBinOp

--- a/Math/NumberTheory/Moduli/Class.hs
+++ b/Math/NumberTheory/Moduli/Class.hs
@@ -50,6 +50,16 @@ import Data.Type.Equality
 import GHC.Natural (Natural(..))
 import GHC.TypeNats.Compat
 
+-- | Linking type and value levels: extract modulo @m@ as a value.
+getMod :: KnownNat m => Mod m -> Integer
+getMod = toInteger . natVal
+{-# INLINE getMod #-}
+
+-- | Linking type and value levels: extract modulo @m@ as a value.
+getNatMod :: KnownNat m => Mod m -> Natural
+getNatMod = natVal
+{-# INLINE getNatMod #-}
+
 -- | This type represents elements of the multiplicative group mod m, i.e.
 -- those elements which are coprime to m. Use @toMultElement@ to construct.
 newtype MultMod m = MultMod {

--- a/Math/NumberTheory/Moduli/Equations.hs
+++ b/Math/NumberTheory/Moduli/Equations.hs
@@ -17,10 +17,11 @@ module Math.NumberTheory.Moduli.Equations
 
 import Data.Constraint
 import Data.Maybe
+import Data.Mod
 import GHC.Integer.GMP.Internals
+import GHC.TypeNats.Compat
 
 import Math.NumberTheory.Moduli.Chinese
-import Math.NumberTheory.Moduli.Class
 import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Moduli.Sqrt
 import Math.NumberTheory.Primes
@@ -39,7 +40,7 @@ solveLinear
   => Mod m   -- ^ a
   -> Mod m   -- ^ b
   -> [Mod m] -- ^ list of x
-solveLinear a b = map fromInteger $ solveLinear' (getMod a) (getVal a) (getVal b)
+solveLinear a b = map fromInteger $ solveLinear' (toInteger (natVal a)) (getVal a) (getVal b)
 
 solveLinear' :: Integer -> Integer -> Integer -> [Integer]
 solveLinear' m a b = case solveLinearCoprime m' (a `quot` d) (b `quot` d) of

--- a/Math/NumberTheory/Moduli/Equations.hs
+++ b/Math/NumberTheory/Moduli/Equations.hs
@@ -40,7 +40,7 @@ solveLinear
   => Mod m   -- ^ a
   -> Mod m   -- ^ b
   -> [Mod m] -- ^ list of x
-solveLinear a b = map fromInteger $ solveLinear' (toInteger (natVal a)) (getVal a) (getVal b)
+solveLinear a b = map fromInteger $ solveLinear' (toInteger (natVal a)) (toInteger (unMod a)) (toInteger (unMod b))
 
 solveLinear' :: Integer -> Integer -> Integer -> [Integer]
 solveLinear' m a b = case solveLinearCoprime m' (a `quot` d) (b `quot` d) of
@@ -76,9 +76,9 @@ solveQuadratic sm a b c = case proofFromSFactors sm of
     $ map (\(p, n) -> (solveQuadraticPrimePower a' b' c' p n, unPrime p ^ n))
     $ unSFactors sm
   where
-    a' = getVal a
-    b' = getVal b
-    c' = getVal c
+    a' = toInteger $ unMod a
+    b' = toInteger $ unMod b
+    c' = toInteger $ unMod c
 
     combine :: [([Integer], Integer)] -> ([Integer], Integer)
     combine = foldl

--- a/Math/NumberTheory/Moduli/PrimitiveRoot.hs
+++ b/Math/NumberTheory/Moduli/PrimitiveRoot.hs
@@ -27,14 +27,14 @@ module Math.NumberTheory.Moduli.PrimitiveRoot
   , isPrimitiveRoot
   ) where
 
+import Control.Monad (guard)
+import Data.Constraint
+
 import Math.NumberTheory.ArithmeticFunctions (totient)
-import Math.NumberTheory.Moduli.Class hiding (powMod)
+import Math.NumberTheory.Moduli.Class (MultMod(..), isMultElement, Mod, getNatVal)
 import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Powers.Modular
 import Math.NumberTheory.Primes
-
-import Control.Monad (guard)
-import Data.Constraint
 
 -- | 'PrimitiveRoot' m is a type which is only inhabited
 -- by <https://en.wikipedia.org/wiki/Primitive_root_modulo_n primitive roots> of m.

--- a/Math/NumberTheory/Moduli/Sqrt.hs
+++ b/Math/NumberTheory/Moduli/Sqrt.hs
@@ -22,9 +22,9 @@ import Control.Monad (liftM2)
 import Data.Bits
 import Data.Constraint
 import Data.Maybe
+import Data.Mod hiding (powMod)
 
 import Math.NumberTheory.Moduli.Chinese
-import Math.NumberTheory.Moduli.Class hiding (powMod)
 import Math.NumberTheory.Moduli.Jacobi
 import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Powers.Modular (powMod)

--- a/Math/NumberTheory/Moduli/Sqrt.hs
+++ b/Math/NumberTheory/Moduli/Sqrt.hs
@@ -39,7 +39,7 @@ import Math.NumberTheory.Utils.FromIntegral
 -- [(1 `modulo` 60),(49 `modulo` 60),(41 `modulo` 60),(29 `modulo` 60),(31 `modulo` 60),(19 `modulo` 60),(11 `modulo` 60),(59 `modulo` 60)]
 sqrtsMod :: SFactors Integer m -> Mod m -> [Mod m]
 sqrtsMod sm a = case proofFromSFactors sm of
-  Sub Dict -> map fromInteger $ sqrtsModFactorisation (getVal a) (unSFactors sm)
+  Sub Dict -> map fromInteger $ sqrtsModFactorisation (toInteger (unMod a)) (unSFactors sm)
 
 -- | List all square roots modulo a number, the factorisation of which is
 -- passed as a second argument.

--- a/Math/NumberTheory/Moduli/Sqrt.hs
+++ b/Math/NumberTheory/Moduli/Sqrt.hs
@@ -22,7 +22,7 @@ import Control.Monad (liftM2)
 import Data.Bits
 import Data.Constraint
 import Data.Maybe
-import Data.Mod hiding (powMod)
+import Data.Mod
 
 import Math.NumberTheory.Moduli.Chinese
 import Math.NumberTheory.Moduli.Jacobi

--- a/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
+++ b/Math/NumberTheory/Primes/Factorisation/Montgomery.hs
@@ -57,7 +57,7 @@ import GHC.TypeNats.Compat
 
 import Math.NumberTheory.Curves.Montgomery
 import Math.NumberTheory.Euclidean.Coprimes (splitIntoCoprimes, unCoprimes)
-import Math.NumberTheory.Moduli.Class
+import Math.NumberTheory.Moduli.Class (SomeMod(..), modulo, Mod, getVal)
 import Math.NumberTheory.Roots.General     (highestPower, largePFPower)
 import Math.NumberTheory.Roots.Squares     (integerSquareRoot')
 import Math.NumberTheory.Primes.Sieve.Eratosthenes (PrimeSieve(..), psieveFrom)
@@ -256,7 +256,7 @@ montgomeryFactorisation b1 b2 s = case newPoint (getVal s) n of
         g -> Just g
       g -> Just g
   where
-    n = getMod s
+    n = toInteger (natVal s)
     smallPowers
       = map findPower
       $ takeWhile (<= b1) (2 : 3 : 5 : list primeStore)

--- a/Math/NumberTheory/Primes/Testing/Certified.hs
+++ b/Math/NumberTheory/Primes/Testing/Certified.hs
@@ -13,7 +13,7 @@ import Data.List
 import Data.Bits
 import GHC.Integer.GMP.Internals
 
-import Math.NumberTheory.Moduli.Class
+import Math.NumberTheory.Moduli.Class (SomeMod(..), modulo)
 import Math.NumberTheory.Roots.Squares
 import Math.NumberTheory.Primes (unPrime)
 import Math.NumberTheory.Primes.Factorisation.TrialDivision

--- a/Math/NumberTheory/Primes/Testing/Probabilistic.hs
+++ b/Math/NumberTheory/Primes/Testing/Probabilistic.hs
@@ -22,7 +22,7 @@ import GHC.Base
 import GHC.Integer.GMP.Internals
 import GHC.TypeNats.Compat
 
-import Math.NumberTheory.Moduli.Class
+import Math.NumberTheory.Moduli.Class (SomeMod(..), modulo, Mod, getVal, (^%))
 import Math.NumberTheory.Moduli.Jacobi
 import Math.NumberTheory.Utils
 import Math.NumberTheory.Roots.Squares

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -49,6 +49,7 @@ library
     semirings >= 0.5.2,
     vector >= 0.12
   exposed-modules:
+    Data.Mod
     GHC.TypeNats.Compat
     Math.NumberTheory.ArithmeticFunctions
     Math.NumberTheory.ArithmeticFunctions.Inverse

--- a/test-suite/Math/NumberTheory/EisensteinIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/EisensteinIntegersTests.hs
@@ -25,8 +25,7 @@ import Test.Tasty.HUnit                               (Assertion, assertEqual,
 
 import qualified Math.NumberTheory.Quadratic.EisensteinIntegers as E
 import Math.NumberTheory.Primes
-import Math.NumberTheory.TestUtils                    (Positive (..),
-                                                       testSmallAndQuick)
+import Math.NumberTheory.TestUtils
 
 -- | Check that @signum@ and @abs@ satisfy @z == signum z * abs z@, where @z@ is
 -- an @EisensteinInteger@.
@@ -182,6 +181,6 @@ testSuite = testGroup "EisensteinIntegers" $
                           factoriseProperty3
       , testCase          "factorise 15:+12" factoriseSpecialCase1
       ]
-  , testGroup "GcdDomain laws" $ map (uncurry QC.testProperty) $ lawsProperties $ gcdDomainLaws (Proxy :: Proxy E.EisensteinInteger)
-  , testGroup "Euclidean laws" $ map (uncurry QC.testProperty) $ lawsProperties $ euclideanLaws (Proxy :: Proxy E.EisensteinInteger)
+  , lawsToTest $ gcdDomainLaws (Proxy :: Proxy E.EisensteinInteger)
+  , lawsToTest $ euclideanLaws (Proxy :: Proxy E.EisensteinInteger)
   ]

--- a/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
+++ b/test-suite/Math/NumberTheory/GaussianIntegersTests.hs
@@ -187,6 +187,6 @@ testSuite = testGroup "GaussianIntegers" $
     , testCase          "(12 :+ 23) (23 :+ 34)" gcdGSpecialCase1
     , testCase          "(0 :+ 3) (2 :+ 2)"     gcdGSpecialCase2
     ]
-  , testGroup "GcdDomain laws" $ map (uncurry QC.testProperty) $ lawsProperties $ gcdDomainLaws (Proxy :: Proxy GaussianInteger)
-  , testGroup "Euclidean laws" $ map (uncurry QC.testProperty) $ lawsProperties $ euclideanLaws (Proxy :: Proxy GaussianInteger)
+  , lawsToTest $ gcdDomainLaws (Proxy :: Proxy GaussianInteger)
+  , lawsToTest $ euclideanLaws (Proxy :: Proxy GaussianInteger)
   ]

--- a/test-suite/Math/NumberTheory/Moduli/ClassTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/ClassTests.hs
@@ -8,6 +8,7 @@
 --
 
 {-# LANGUAGE CPP             #-}
+{-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE ViewPatterns    #-}
 
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
@@ -20,7 +21,9 @@ import Test.Tasty
 import qualified Test.Tasty.QuickCheck as QC
 
 import Data.Maybe
+import Data.Proxy
 import Numeric.Natural
+import Test.QuickCheck.Classes
 
 import Math.NumberTheory.Moduli hiding (invertMod)
 import Math.NumberTheory.TestUtils
@@ -190,4 +193,40 @@ testSuite = testGroup "Class"
     , testSmallAndQuick "mul" infModMulProperty
     ]
   , testSmallAndQuick "getVal/getMod" getValModProperty
+
+  , testGroup "Mod 1" $ map lawsToTest $ let p = Proxy :: Proxy (Mod 1) in
+    [ eqLaws          p
+    , ordLaws         p
+    , numLaws         p
+    , semiringLaws    p
+    , ringLaws        p
+    , showLaws        p
+    ]
+  , testGroup "Mod 2310" $ map lawsToTest $ let p = Proxy :: Proxy (Mod 2310) in
+    [ eqLaws          p
+    , ordLaws         p
+    , boundedEnumLaws p
+    , numLaws         p
+    , semiringLaws    p
+    , ringLaws        p
+    , showLaws        p
+    ]
+  , testGroup "Mod 123456789012345678901234567890" $ map lawsToTest $ let p = Proxy :: Proxy (Mod 123456789012345678901234567890) in
+    [ eqLaws          p
+    , ordLaws         p
+    , boundedEnumLaws p
+    , numLaws         p
+    , semiringLaws    p
+    , ringLaws        p
+    , showLaws        p
+    ]
+  , testGroup "Mod 18446744073709551626" $ map lawsToTest $ let p = Proxy :: Proxy (Mod 18446744073709551626) in
+    [ eqLaws          p
+    , ordLaws         p
+    , boundedEnumLaws p
+    , numLaws         p
+    , semiringLaws    p
+    , ringLaws        p
+    , showLaws        p
+    ]
   ]

--- a/test-suite/Math/NumberTheory/Moduli/DiscreteLogarithmTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/DiscreteLogarithmTests.hs
@@ -14,7 +14,7 @@ import Data.Proxy
 import GHC.TypeNats.Compat
 
 import Math.NumberTheory.ArithmeticFunctions (totient)
-import Math.NumberTheory.Moduli.Class
+import Math.NumberTheory.Moduli.Class (isMultElement)
 import Math.NumberTheory.Moduli.DiscreteLogarithm
 import Math.NumberTheory.Moduli.PrimitiveRoot
 import Math.NumberTheory.Moduli.Singleton

--- a/test-suite/Math/NumberTheory/Moduli/EquationsTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/EquationsTests.hs
@@ -14,11 +14,11 @@ module Math.NumberTheory.Moduli.EquationsTests
 import Test.Tasty
 
 import Data.List
+import Data.Mod
 import Data.Proxy
 import GHC.TypeNats.Compat
 import Numeric.Natural
 
-import Math.NumberTheory.Moduli.Class
 import Math.NumberTheory.Moduli.Equations
 import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.TestUtils

--- a/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/PrimitiveRootTests.hs
@@ -29,7 +29,7 @@ import GHC.TypeNats.Compat
 import Numeric.Natural
 
 import Math.NumberTheory.ArithmeticFunctions (totient)
-import Math.NumberTheory.Moduli.Class
+import Math.NumberTheory.Moduli.Class (getVal, multElement)
 import Math.NumberTheory.Moduli.PrimitiveRoot
 import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Primes

--- a/test-suite/Math/NumberTheory/Powers/SquaresTests.hs
+++ b/test-suite/Math/NumberTheory/Powers/SquaresTests.hs
@@ -18,8 +18,6 @@ module Math.NumberTheory.Powers.SquaresTests
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Data.Maybe
-
 import Math.NumberTheory.Roots
 import Math.NumberTheory.TestUtils
 


### PR DESCRIPTION
This PR closes #171 and separates `newtype Mod` to an independent module `Data.Mod`.

@Multramate does `Data.Mod` look lightweight enough? I intend to move it to a new package, as we discussed in https://github.com/adjoint-io/galois-field/issues/9