### PR TITLE
Chinese remainder theorem on a list

### DIFF
--- a/Math/NumberTheory/Moduli/Chinese.hs
+++ b/Math/NumberTheory/Moduli/Chinese.hs
@@ -22,7 +22,9 @@
 module Math.NumberTheory.Moduli.Chinese
   ( -- * Safe interface
     chinese
+  , chineseList
   , chineseCoprime
+  , chineseCoprimeList
   , chineseSomeMod
   , chineseCoprimeSomeMod
 
@@ -68,6 +70,23 @@ chineseCoprime (n1, m1) (n2, m2)
 {-# SPECIALISE chineseCoprime :: (Word, Word) -> (Word, Word) -> Maybe Word #-}
 {-# SPECIALISE chineseCoprime :: (Integer, Integer) -> (Integer, Integer) -> Maybe Integer #-}
 
+-- | Given a list @[(r_1,m_1), ..., (r_n,m_n)]@ of @(residue,modulus)@
+--   pairs, @chineseCoprimeList@ calculates the solution to the simultaneous
+--   congruences
+--
+-- >
+-- > r ≡ r_k (mod m_k)
+-- >
+--
+--   if all moduli are positive and pairwise coprime. Otherwise
+--   the result is @Nothing@.
+chineseCoprimeList :: (Eq a, Ring a, Euclidean a) => [(a, a)] -> Maybe a
+chineseCoprimeList = fmap fst . foldM (\x y -> fmap (,snd x `times` snd y) (chineseCoprime x y)) (zero, one)
+
+{-# SPECIALISE chineseCoprimeList :: [(Int, Int)] -> Maybe Int #-}
+{-# SPECIALISE chineseCoprimeList :: [(Word, Word)] -> Maybe Word #-}
+{-# SPECIALISE chineseCoprimeList :: [(Integer, Integer)] -> Maybe Integer #-}
+
 -- | 'chinese' @(n1, m1)@ @(n2, m2)@ returns @n@ such that
 -- @n \`mod\` m1 == n1@ and @n \`mod\` m2 == n2@, if exists.
 -- Moduli @m1@ and @m2@ are allowed to have common factors.
@@ -107,6 +126,13 @@ chinese (n1, m1) (n2, m2)
 {-# SPECIALISE chinese :: (Int, Int) -> (Int, Int) -> Maybe Int #-}
 {-# SPECIALISE chinese :: (Word, Word) -> (Word, Word) -> Maybe Word #-}
 {-# SPECIALISE chinese :: (Integer, Integer) -> (Integer, Integer) -> Maybe Integer #-}
+
+chineseList :: forall a. (Eq a, Ring a, Euclidean a) => [(a, a)] -> Maybe a
+chineseList = fmap fst . foldM (\x y -> fmap (,snd x `lcm` snd y) (chinese x y)) (zero, one)
+
+{-# SPECIALISE chineseList :: [(Int, Int)] -> Maybe Int #-}
+{-# SPECIALISE chineseList :: [(Word, Word)] -> Maybe Word #-}
+{-# SPECIALISE chineseList :: [(Integer, Integer)] -> Maybe Integer #-}
 
 isCompatible :: KnownNat m => Mod m -> Rational -> Bool
 isCompatible n r = case invertMod (fromInteger (denominator r)) of

--- a/test-suite/Math/NumberTheory/Moduli/ChineseTests.hs
+++ b/test-suite/Math/NumberTheory/Moduli/ChineseTests.hs
@@ -18,6 +18,7 @@ module Math.NumberTheory.Moduli.ChineseTests
 
 import Test.Tasty
 
+import Data.List (tails)
 import Math.NumberTheory.Moduli hiding (invertMod)
 import Math.NumberTheory.TestUtils
 
@@ -29,6 +30,17 @@ chineseCoprimeProperty n1 (Positive m1) n2 (Positive m2) = case gcd m1 m2 of
   _ -> case chineseCoprime (n1, m1) (n2, m2) of
     Nothing -> True
     Just{}  -> False
+
+chineseCoprimeListProperty :: [(Integer, Positive Integer)] -> Bool
+chineseCoprimeListProperty xs =
+  if and [gcd r1 r2 == 1 | ((_, r1) :ys) <- tails xs', (_, r2) <- ys]
+     then case chineseCoprimeList xs' of
+            Nothing -> False
+            Just n -> and [(n - r) `rem` m == 0 | (r, m) <- xs']
+     else case chineseCoprimeList xs' of
+            Nothing -> True
+            Just _  -> False
+  where xs' = [(r, m) | (r, Positive m) <- xs]
 
 chineseProperty :: Integer -> Positive Integer -> Integer -> Positive Integer -> Bool
 chineseProperty n1 (Positive m1) n2 (Positive m2) = if compatible
@@ -42,9 +54,13 @@ chineseProperty n1 (Positive m1) n2 (Positive m2) = if compatible
     g = gcd m1 m2
     compatible = (n1 - n2) `rem` g == 0
 
+chineseListProperty :: [(Integer, Positive Integer)] -> Bool
+chineseListProperty _ = True
 
 testSuite :: TestTree
 testSuite = testGroup "Chinese"
-  [ testSmallAndQuick "chineseCoprime"    chineseCoprimeProperty
-  , testSmallAndQuick "chinese"           chineseProperty
+  [ testSmallAndQuick "chineseCoprime"     chineseCoprimeProperty
+  , testSmallAndQuick "chineseCoprimeList" chineseCoprimeListProperty
+  , testSmallAndQuick "chinese"            chineseProperty
+  , testSmallAndQuick "chineseList"        chineseListProperty
   ]


### PR DESCRIPTION
Motivation:
- It is useful to have chinese remainder theorem on more than two arguments
- `chineseRemainder` supported this but has now been deprecated, `chineseCoprimeList` restores this functionality.

I'm not sure what the right test for `chineseList` is - it's unclear to me how to generalise compatibility. Feel free to advise, or add commits to this PR.