### PR TITLE
Move roots of unity to utils and ignore vim .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 dist-newstyle
 .ghc.environment*
 .tasty-rerun-log
+.swp

--- a/Math/NumberTheory/DirichletCharacters.hs
+++ b/Math/NumberTheory/DirichletCharacters.hs
@@ -83,8 +83,8 @@ import Math.NumberTheory.Moduli.Multiplicative             (MultMod(..), isMultE
 import Math.NumberTheory.Moduli.Singleton                  (Some(..), cyclicGroupFromFactors)
 import Math.NumberTheory.Powers.Modular                    (powMod)
 import Math.NumberTheory.Primes                            (Prime(..), UniqueFactorisation, factorise, nextPrime)
+import Math.NumberTheory.RootsOfUnity
 import Math.NumberTheory.Utils.FromIntegral                (wordToInt)
-import Math.NumberTheory.Utils.RootsOfUnity
 import Math.NumberTheory.Utils
 
 -- | A Dirichlet character mod \(n\) is a group homomorphism from \((\mathbb{Z}/n\mathbb{Z})^*\)

--- a/Math/NumberTheory/DirichletCharacters.hs
+++ b/Math/NumberTheory/DirichletCharacters.hs
@@ -19,14 +19,8 @@
 
 module Math.NumberTheory.DirichletCharacters
   (
-  -- * Roots of unity
-    RootOfUnity
-  -- ** Conversions
-  , toRootOfUnity
-  , fromRootOfUnity
-  , toComplex
   -- * An absorbing semigroup
-  , OrZero, pattern Zero, pattern NonZero
+  OrZero, pattern Zero, pattern NonZero
   , orZeroToNum
   -- * Dirichlet characters
   , DirichletCharacter
@@ -65,7 +59,6 @@ module Math.NumberTheory.DirichletCharacters
 import Control.Applicative                                 (liftA2)
 #endif
 import Data.Bits                                           (Bits(..))
-import Data.Complex                                        (Complex(..), cis)
 import Data.Foldable                                       (for_)
 import Data.Functor.Identity                               (Identity(..))
 import Data.List                                           (mapAccumL, foldl', sort, find, unfoldr)
@@ -75,7 +68,7 @@ import Data.Monoid                                         (Ap(..))
 #endif
 import Data.Proxy                                          (Proxy(..))
 import Data.Ratio                                          ((%), numerator, denominator)
-import Data.Semigroup                                      (Semigroup(..), Product(..))
+import Data.Semigroup                                      (Semigroup(..),Product(..))
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as MV
 import Data.Vector                                         (Vector, (!))
@@ -91,6 +84,7 @@ import Math.NumberTheory.Moduli.Singleton                  (Some(..), cyclicGrou
 import Math.NumberTheory.Powers.Modular                    (powMod)
 import Math.NumberTheory.Primes                            (Prime(..), UniqueFactorisation, factorise, nextPrime)
 import Math.NumberTheory.Utils.FromIntegral                (wordToInt)
+import Math.NumberTheory.Utils.RootsOfUnity
 import Math.NumberTheory.Utils
 
 -- | A Dirichlet character mod \(n\) is a group homomorphism from \((\mathbb{Z}/n\mathbb{Z})^*\)
@@ -138,52 +132,6 @@ instance Eq DirichletFactor where
   OddPrime _ _ _ x == OddPrime _ _ _ y = x == y
   Two              == Two              = True
   _ == _ = False
-
--- | A representation of <https://en.wikipedia.org/wiki/Root_of_unity roots of unity>: complex
--- numbers \(z\) for which there is \(n\) such that \(z^n=1\).
-newtype RootOfUnity =
-  RootOfUnity { -- | Every root of unity can be expressed as \(e^{2 \pi i q}\) for some
-                -- rational \(q\) satisfying \(0 \leq q < 1\), this function extracts it.
-                fromRootOfUnity :: Rational }
-  deriving (Eq)
-
-instance Show RootOfUnity where
-  show (RootOfUnity q)
-    | n == 0    = "1"
-    | d == 1    = "-1"
-    | n == 1    = "e^(πi/" ++ show d ++ ")"
-    | otherwise = "e^(" ++ show n ++ "πi/" ++ show d ++ ")"
-    where n = numerator (2*q)
-          d = denominator (2*q)
-
--- | Given a rational \(q\), produce the root of unity \(e^{2 \pi i q}\).
-toRootOfUnity :: Rational -> RootOfUnity
-toRootOfUnity q = RootOfUnity ((n `rem` d) % d)
-  where n = numerator q
-        d = denominator q
-        -- effectively q `mod` 1
-  -- This smart constructor ensures that the rational is always in the range 0 <= q < 1.
-
--- | This Semigroup is in fact a group, so @'stimes'@ can be called with a negative first argument.
-instance Semigroup RootOfUnity where
-  RootOfUnity q1 <> RootOfUnity q2 = toRootOfUnity (q1 + q2)
-  stimes k (RootOfUnity q) = toRootOfUnity (q * fromIntegral k)
-
-instance Monoid RootOfUnity where
-  mappend = (<>)
-  mempty = RootOfUnity 0
-
--- | Convert a root of unity into an inexact complex number. Due to floating point inaccuracies,
--- it is recommended to avoid use of this until the end of a calculation. Alternatively, with
--- the [cyclotomic](http://hackage.haskell.org/package/cyclotomic-0.5.1) package, one can use
--- @[polarRat](https://hackage.haskell.org/package/cyclotomic-0.5.1/docs/Data-Complex-Cyclotomic.html#v:polarRat)
--- 1 . @'fromRootOfUnity' to convert to a cyclotomic number.
-toComplex :: Floating a => RootOfUnity -> Complex a
-toComplex (RootOfUnity t)
-  | t == 1/2 = (-1) :+ 0
-  | t == 1/4 = 0 :+ 1
-  | t == 3/4 = 0 :+ (-1)
-  | otherwise = cis . (2*pi*) . fromRational $ t
 
 -- | For primes, define the canonical primitive root as the smallest such. For prime powers \(p^k\),
 -- either the smallest primitive root \(g\) mod \(p\) works, or \(g+p\) works.

--- a/Math/NumberTheory/RootsOfUnity.hs
+++ b/Math/NumberTheory/RootsOfUnity.hs
@@ -1,4 +1,11 @@
-module Math.NumberTheory.Utils.RootsOfUnity
+-- |
+-- Module:      Math.NumberTheory.RootsOfUnity
+-- Licence:     MIT
+--
+-- Implementation of roots of unity
+--
+
+module Math.NumberTheory.RootsOfUnity
 (  
 -- * Roots of unity
    RootOfUnity (..)

--- a/Math/NumberTheory/RootsOfUnity.hs
+++ b/Math/NumberTheory/RootsOfUnity.hs
@@ -1,9 +1,12 @@
 -- |
 -- Module:      Math.NumberTheory.RootsOfUnity
+-- Copyright:   (c) 2018 Bhavik Mehta
 -- Licence:     MIT
+-- Maintainer:  Bhavik Mehta <bhavikmehta8@gmail.com>
 --
 -- Implementation of roots of unity
 --
+
 
 module Math.NumberTheory.RootsOfUnity
 (  

--- a/Math/NumberTheory/Utils/RootsOfUnity.hs
+++ b/Math/NumberTheory/Utils/RootsOfUnity.hs
@@ -1,0 +1,59 @@
+module Math.NumberTheory.Utils.RootsOfUnity
+(  
+-- * Roots of unity
+   RootOfUnity (..)
+-- ** Conversions
+   , toRootOfUnity
+   , toComplex )
+
+where
+
+import Data.Complex                                        (Complex(..), cis)
+import Data.Semigroup                                      (Semigroup(..))
+import Data.Ratio                                          ((%), numerator, denominator)
+
+-- | A representation of <https://en.wikipedia.org/wiki/Root_of_unity roots of unity>: complex
+-- numbers \(z\) for which there is \(n\) such that \(z^n=1\).
+newtype RootOfUnity =
+  RootOfUnity { -- | Every root of unity can be expressed as \(e^{2 \pi i q}\) for some
+                -- rational \(q\) satisfying \(0 \leq q < 1\), this function extracts it.
+                fromRootOfUnity :: Rational }
+  deriving (Eq)
+
+instance Show RootOfUnity where
+  show (RootOfUnity q)
+    | n == 0    = "1"
+    | d == 1    = "-1"
+    | n == 1    = "e^(πi/" ++ show d ++ ")"
+    | otherwise = "e^(" ++ show n ++ "πi/" ++ show d ++ ")"
+    where n = numerator (2*q)
+          d = denominator (2*q)
+
+-- | Given a rational \(q\), produce the root of unity \(e^{2 \pi i q}\).
+toRootOfUnity :: Rational -> RootOfUnity
+toRootOfUnity q = RootOfUnity ((n `rem` d) % d)
+  where n = numerator q
+        d = denominator q
+        -- effectively q `mod` 1
+  -- This smart constructor ensures that the rational is always in the range 0 <= q < 1.
+
+-- | This Semigroup is in fact a group, so @'stimes'@ can be called with a negative first argument.
+instance Semigroup RootOfUnity where
+  RootOfUnity q1 <> RootOfUnity q2 = toRootOfUnity (q1 + q2)
+  stimes k (RootOfUnity q) = toRootOfUnity (q * fromIntegral k)
+
+instance Monoid RootOfUnity where
+  mappend = (<>)
+  mempty = RootOfUnity 0
+
+-- | Convert a root of unity into an inexact complex number. Due to floating point inaccuracies,
+-- it is recommended to avoid use of this until the end of a calculation. Alternatively, with
+-- the [cyclotomic](http://hackage.haskell.org/package/cyclotomic-0.5.1) package, one can use
+-- @[polarRat](https://hackage.haskell.org/package/cyclotomic-0.5.1/docs/Data-Complex-Cyclotomic.html#v:polarRat)
+-- 1 . @'fromRootOfUnity' to convert to a cyclotomic number.
+toComplex :: Floating a => RootOfUnity -> Complex a
+toComplex (RootOfUnity t)
+  | t == 1/2 = (-1) :+ 0
+  | t == 1/4 = 0 :+ 1
+  | t == 3/4 = 0 :+ (-1)
+  | otherwise = cis . (2*pi*) . fromRational $ t

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -91,6 +91,7 @@ library
     Math.NumberTheory.Recurrences.Bilinear
     Math.NumberTheory.Recurrences.Linear
     Math.NumberTheory.SmoothNumbers
+    Math.NumberTheory.Utils.RootsOfUnity
     Math.NumberTheory.Zeta
   other-modules:
     Math.NumberTheory.ArithmeticFunctions.Class

--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -90,8 +90,8 @@ library
     Math.NumberTheory.Recurrences
     Math.NumberTheory.Recurrences.Bilinear
     Math.NumberTheory.Recurrences.Linear
+    Math.NumberTheory.RootsOfUnity
     Math.NumberTheory.SmoothNumbers
-    Math.NumberTheory.Utils.RootsOfUnity
     Math.NumberTheory.Zeta
   other-modules:
     Math.NumberTheory.ArithmeticFunctions.Class
@@ -174,6 +174,7 @@ test-suite spec
     Math.NumberTheory.Recurrences.PentagonalTests
     Math.NumberTheory.Recurrences.BilinearTests
     Math.NumberTheory.Recurrences.LinearTests
+    Math.NumberTheory.RootsOfUnityTests
     Math.NumberTheory.SmoothNumbersTests
     Math.NumberTheory.TestUtils
     Math.NumberTheory.TestUtils.MyCompose

--- a/test-suite/Math/NumberTheory/DirichletCharactersTests.hs
+++ b/test-suite/Math/NumberTheory/DirichletCharactersTests.hs
@@ -1,5 +1,5 @@
 -- |
--- Module:       Math.NumberTheory.Moduli.DiscreteLogarithm
+-- Module:       Math.NumberTheory.DirichletCharactersTests
 -- Copyright:    (c) 2018 Bhavik Mehta
 -- License:      MIT
 -- Maintainer:   Andrew Lelechenko <andrew.lelechenko@gmail.com>

--- a/test-suite/Math/NumberTheory/DirichletCharactersTests.hs
+++ b/test-suite/Math/NumberTheory/DirichletCharactersTests.hs
@@ -22,7 +22,6 @@ import Data.Complex
 import Data.List (genericLength)
 import Data.Maybe (isJust, mapMaybe)
 import Data.Proxy
-import Data.Ratio
 import Data.Semigroup
 import qualified Data.Vector as V
 import Numeric.Natural
@@ -35,10 +34,7 @@ import Math.NumberTheory.DirichletCharacters
 import qualified Math.NumberTheory.Moduli.Sqrt as J
 import Math.NumberTheory.Moduli.Class (SomeMod(..), modulo)
 import Math.NumberTheory.TestUtils (testSmallAndQuick, Positive(..))
-import Math.NumberTheory.Utils.RootsOfUnity
-
-rootOfUnityTest :: Integer -> Positive Integer -> Bool
-rootOfUnityTest n (Positive d) = toComplex ((d `div` gcd n d) `stimes` toRootOfUnity (n % d)) == (1 :: Complex Double)
+import Math.NumberTheory.RootsOfUnity
 
 -- | This tests property 6 from https://en.wikipedia.org/wiki/Dirichlet_character#Axiomatic_definition
 dirCharOrder :: forall n. KnownNat n => DirichletCharacter n -> Bool
@@ -223,8 +219,7 @@ makePrimitiveValid chi = case makePrimitive chi of
 
 testSuite :: TestTree
 testSuite = testGroup "DirichletCharacters"
-  [ testSmallAndQuick "RootOfUnity contains roots of unity" rootOfUnityTest
-  , testSmallAndQuick "Dirichlet characters divide the right order" (dirCharProperty dirCharOrder)
+  [ testSmallAndQuick "Dirichlet characters divide the right order" (dirCharProperty dirCharOrder)
   , testSmallAndQuick "Dirichlet characters are multiplicative" (dirCharProperty testMultiplicative)
   , testSmallAndQuick "Dirichlet characters are 1 at 1" (dirCharProperty testAtOne)
   , testSmallAndQuick "Right number of Dirichlet characters" countCharacters

--- a/test-suite/Math/NumberTheory/DirichletCharactersTests.hs
+++ b/test-suite/Math/NumberTheory/DirichletCharactersTests.hs
@@ -35,6 +35,7 @@ import Math.NumberTheory.DirichletCharacters
 import qualified Math.NumberTheory.Moduli.Sqrt as J
 import Math.NumberTheory.Moduli.Class (SomeMod(..), modulo)
 import Math.NumberTheory.TestUtils (testSmallAndQuick, Positive(..))
+import Math.NumberTheory.Utils.RootsOfUnity
 
 rootOfUnityTest :: Integer -> Positive Integer -> Bool
 rootOfUnityTest n (Positive d) = toComplex ((d `div` gcd n d) `stimes` toRootOfUnity (n % d)) == (1 :: Complex Double)

--- a/test-suite/Math/NumberTheory/RootsOfUnityTests.hs
+++ b/test-suite/Math/NumberTheory/RootsOfUnityTests.hs
@@ -1,6 +1,8 @@
 -- |
 -- Module:       Math.NumberTheory.RootsOfUnityTests
--- Licence:      MIT
+-- Copyright:    (c) 2018 Bhavik Mehta
+-- License:      MIT
+-- Maintainer:   Andrew Lelechenko <andrew.lelechenko@gmail.com>
 --
 -- Tests for Math.NumberTheory.RootsOfUnity
 --

--- a/test-suite/Math/NumberTheory/RootsOfUnityTests.hs
+++ b/test-suite/Math/NumberTheory/RootsOfUnityTests.hs
@@ -1,0 +1,23 @@
+-- |
+-- Module:       Math.NumberTheory.RootsOfUnityTests
+-- Licence:      MIT
+--
+-- Tests for Math.NumberTheory.RootsOfUnity
+--
+
+module Math.NumberTheory.RootsOfUnityTests where
+
+import Test.Tasty
+
+import Data.Complex
+import Data.Ratio
+import Data.Semigroup
+
+import Math.NumberTheory.RootsOfUnity
+import Math.NumberTheory.TestUtils (testSmallAndQuick, Positive(..))
+
+rootOfUnityTest :: Integer -> Positive Integer -> Bool
+rootOfUnityTest n (Positive d) = toComplex ((d `div` gcd n d) `stimes` toRootOfUnity (n % d)) == (1 :: Complex Double)
+
+testSuite :: TestTree
+testSuite = testSmallAndQuick "RootOfUnity contains roots of unity" rootOfUnityTest

--- a/test-suite/Test.hs
+++ b/test-suite/Test.hs
@@ -46,6 +46,8 @@ import qualified Math.NumberTheory.Zeta.DirichletTests as Dirichlet
 
 import qualified Math.NumberTheory.DirichletCharactersTests as DirichletChar
 
+import qualified Math.NumberTheory.RootsOfUnityTests as RootsOfUnity
+
 main :: IO ()
 main = defaultMainWithRerun tests
 
@@ -95,4 +97,5 @@ tests = testGroup "All"
     , Dirichlet.testSuite
     ]
   , DirichletChar.testSuite
+  , RootsOfUnity.testSuite
   ]


### PR DESCRIPTION
This moves roots of unity to the utilities section.

It leaves it as an exposed module so that the tests can build.