### PR TITLE
Adding Divisors.hs to get all the factors of a number in a given range

### DIFF
--- a/Math/NumberTheory/Divisors.hs
+++ b/Math/NumberTheory/Divisors.hs
@@ -1,46 +1,124 @@
 import System.IO
 import Data.Ratio
+-- import Math.NumberTheory.Primes.factorise
+import Data.List
 
 
+
+
+headInt :: [Integer] -> Integer
+headInt (x:xs) =x
+
+
+-- mylog recTakeEachPrimetion here take two numbers a and b and gives the maximum 
+-- power of b that appears in a
 mylog :: Integer -> Integer -> Integer
 mylog a b 
 	| ((a `mod` b) /= 0)  = 0
 	| otherwise = (1 + mylog (a `div` b) b)
 
 
+
+
+-- getfactors takes two arguments the number 'n' that you want to factorise 
+-- and a number 'st' that should be kept to '2' while calling the recTakeEachPrimetion so 
+-- that prime factorization starts from 2 and goes upto sqrt(n) 
+
+
+
 getfactors :: Integer -> Integer -> [(Integer,Integer)]
 getfactors 1 _ = []
 getfactors n st
-		| lst == []  = [(n,1)]
-		| otherwise	= (((head lst), (mylog n (head lst))):getfactors ( n `div` ((head lst) ^ (mylog n (head lst) ))) ((head lst)+1))
+		| lst == [] = [(n,1)]
+		| otherwise	= 
+			(((headInt lst), (mylog n (headInt lst))):getfactors ( n `div` ((headInt lst) ^ (mylog n (headInt lst) ))) ((headInt lst)+1))
 			where lst = (take 1 $ filter (\y -> (n `mod` y) == 0) [st .. (floor (sqrt (fromIntegral n)))])
 				
 
+-- precalc if use for some precalculations that are needed to be done 
+-- to find factors of a number n. you need to pass n and the list of primefactors of n with 
+-- its count and this will produce a list of same length as the list of prime factors which contains the 
+-- residue of n after taking out all the primefactors of it which appear before the current index
+-- For example:
+-- 	precalc 150 [(2 1), (3 1), (5 2)] = [150/2 , 150/2/3 , 150/2/3/25]= [75 , 25 , 1]
+
 precalc :: Integer -> [(Integer,Integer)] -> [Integer]
 precalc n [] = []
-precalc n (x:[]) = [n `div` (fst x ^ snd x )] 
-precalc n (x:xs) = (n `div` (fst x ^ snd x )): (precalc (n `div` ((fst x) ^ (snd x) )) xs)
+precalc n ((x,y):[]) = [n `div` (x ^ y )] 
+precalc n ((x,y):xs) = (n `div` (x ^ y )): (precalc (n `div` (x ^ y)) xs)
 
 
-func :: Integer -> Integer -> [(Integer,Integer)] -> Int -> Integer -> Integer -> [Integer] -> [Integer]
-func i temp fact ind a b arr 
-	| (ind ==  (length fact)) = if (temp <= b && temp >= a) then [temp] else []
-	| ( (i <= (snd (fact!!ind))) && temp > b) = []
-	| ( (i <= (snd (fact!!ind))) && ((temp*(arr!!ind)) <= a)) = ((func (i+1) (temp * (fst (fact!!ind))) fact ind a b arr)  )
-	| (i <= (snd (fact!!ind))) = ( (func 0 (temp) fact (ind+1) a b arr) ++ (func (i+1) (temp * (fst (fact!!ind))) fact ind a b arr)  ) 
-	| otherwise = []
+
+-- recTakeEachPrime function takes index i denoting count of prime present at index 'ind' in 
+-- the prime list that are taken and multiplied to temp at the current pint 
+-- in recursion tree. 
+
+-- Initially i and ind need to be set to 0 
+
+-- temp denotes the value of the number formed in the function by now taking all combinations 
+-- of primes till index 'idx'.
+
+-- fact is the list of prime factors with its count and a and b are such 
+-- that [a,b] represents range in which factors are needed.
+
+-- arr is the list returned bt precalc function and is used at each point to check if going 
+-- down in that branch of the tree will fetch me some factor greater that a or not.
+-- Basically it checks that by multiplying temp to arr[ind] and checking that even after multiplying 
+-- the highest powers of the remaining primes with temp can we get a number greater than a or not. 
+
+
+-- For example take n = 15 = 2* 3 *5^2    a= 26 , b= 100
+
+
+--                            1
+
+
+
+--                      /           \
+--                     1             2
+
+
+-- 				        \         /      \
+-- 				         3        2       6
+            
+            
+--     		  	       / |  \     /  | \    / |  \  
+--    			 	        75         50     30  
+ 
+
+--  30 50 and 75 will be the required factors 
+-- So the deapth of the recursion tree will be equal to number of distinct prime factors and the
+-- width would be the number of factors needed.
+
+
+recTakeEachPrime :: Integer -> Integer -> [(Integer,Integer)] -> Integer -> Integer -> [Integer] -> [Integer]
+recTakeEachPrime i temp [] a b [] 
+	= if (temp <= b && temp >= a) then [temp] else []
+recTakeEachPrime i temp ((x,x'):xs) a b (y:ys) 
+
+	| i <= (x') 
+	, temp > b 
+	= []
+
+	| i <= (x')
+	, (temp*(y)) <= a
+	= ((recTakeEachPrime (i+1) (temp * (x)) ((x,x'):xs) a b (y:ys)) )
+
+	| i <= (x') 
+	= ( (recTakeEachPrime 0 (temp) xs a b ys) ++ (recTakeEachPrime (i+1) (temp * (x)) ((x,x'):xs) a b (y:ys))  ) 
+
+	| otherwise 
+	= []
+
+
+-- divisorsInRange takes three argument from to and n .
+-- The first two takes the range [from , to] of the factors needed 
+-- and n denotes the number whose factore we need
 
 -- divisorsInRange :: (Ord a, UniqueFactorisation a) => a -> a -> a -> [a]
 divisorsInRange :: Integer -> Integer -> Integer -> [Integer]
-divisorsInRange from to n = func 0 1 (getfactors n 2) 0 from to (precalc n (getfactors n 2))
+divisorsInRange from to n = 
+	recTakeEachPrime 0 1 (getfactors n 2) from to (precalc n (getfactors n 2))
 	
--- if sorted list required
-quicksort :: [Integer] -> [Integer]
-quicksort (x:xs) = lft ++ [x] ++ rgt
-	where 
-		lft = quicksort [a | a <- xs, a <= x]
-		rgt = quicksort [a | a <- xs, a > x]
-quicksort [] = []
-
 
 

--- a/Math/NumberTheory/Divisors.hs
+++ b/Math/NumberTheory/Divisors.hs
@@ -1,0 +1,46 @@
+import System.IO
+import Data.Ratio
+
+
+mylog :: Integer -> Integer -> Integer
+mylog a b 
+	| ((a `mod` b) /= 0)  = 0
+	| otherwise = (1 + mylog (a `div` b) b)
+
+
+getfactors :: Integer -> Integer -> [(Integer,Integer)]
+getfactors 1 _ = []
+getfactors n st
+		| lst == []  = [(n,1)]
+		| otherwise	= (((head lst), (mylog n (head lst))):getfactors ( n `div` ((head lst) ^ (mylog n (head lst) ))) ((head lst)+1))
+			where lst = (take 1 $ filter (\y -> (n `mod` y) == 0) [st .. (floor (sqrt (fromIntegral n)))])
+				
+
+precalc :: Integer -> [(Integer,Integer)] -> [Integer]
+precalc n [] = []
+precalc n (x:[]) = [n `div` (fst x ^ snd x )] 
+precalc n (x:xs) = (n `div` (fst x ^ snd x )): (precalc (n `div` ((fst x) ^ (snd x) )) xs)
+
+
+func :: Integer -> Integer -> [(Integer,Integer)] -> Int -> Integer -> Integer -> [Integer] -> [Integer]
+func i temp fact ind a b arr 
+	| (ind ==  (length fact)) = if (temp <= b && temp >= a) then [temp] else []
+	| ( (i <= (snd (fact!!ind))) && temp > b) = []
+	| ( (i <= (snd (fact!!ind))) && ((temp*(arr!!ind)) <= a)) = ((func (i+1) (temp * (fst (fact!!ind))) fact ind a b arr)  )
+	| (i <= (snd (fact!!ind))) = ( (func 0 (temp) fact (ind+1) a b arr) ++ (func (i+1) (temp * (fst (fact!!ind))) fact ind a b arr)  ) 
+	| otherwise = []
+
+-- divisorsInRange :: (Ord a, UniqueFactorisation a) => a -> a -> a -> [a]
+divisorsInRange :: Integer -> Integer -> Integer -> [Integer]
+divisorsInRange from to n = func 0 1 (getfactors n 2) 0 from to (precalc n (getfactors n 2))
+	
+-- if sorted list required
+quicksort :: [Integer] -> [Integer]
+quicksort (x:xs) = lft ++ [x] ++ rgt
+	where 
+		lft = quicksort [a | a <- xs, a <= x]
+		rgt = quicksort [a | a <- xs, a > x]
+quicksort [] = []
+
+
+


### PR DESCRIPTION
In my code the function ```func``` is basically going in a recursion to get all the factors from the prime factors we already calculated. It is first taking the first prime factor from the list from ```0``` to ```y``` number of times where y is the max count of that prime factor in the given number as  i , and for each i calling``` func``` recursively to second prime factor in the list and so on. The only optimisation will be not to go in the direction that will make the factors go out of the range and so at each point I am checking if going down the tree will make me get any factor in the range or not. If I find that I wont be getting any factor  if I proceed down that way I break at that point and wont continue in that direction.
For example lets take 4 25 48 . Here is how my tree would look like.
<pre>
                         1
                   /    /   \     \     \ 
                  1    2    4      8     16 
                     / |   / |    / |    /  
                    2  6  4 12   8 24  16   
 </pre>
The depth would be equal to the number of distinct factors and width would be equal to the number of factors in the given range.
The will do the other changes specified and commit
Fixes #183
 


