### PR TITLE
Fix documentation for construction of MultMod m

### DIFF
--- a/Math/NumberTheory/Moduli/Multiplicative.hs
+++ b/Math/NumberTheory/Moduli/Multiplicative.hs
@@ -35,7 +35,7 @@ import Math.NumberTheory.Moduli.Singleton
 import Math.NumberTheory.Primes
 
 -- | This type represents elements of the multiplicative group mod m, i.e.
--- those elements which are coprime to m. Use @toMultElement@ to construct.
+-- those elements which are coprime to m. Use @isMultElement@ to construct.
 newtype MultMod m = MultMod {
   multElement :: Mod m -- ^ Unwrap a residue.
   } deriving (Eq, Ord, Show)


### PR DESCRIPTION
There's no function called `toMultElement` as far as I can tell.