### PR TITLE
Add "-O2" to all "ghc_options" parts of cabal file...

### DIFF
--- a/arithmoi.cabal
+++ b/arithmoi.cabal
@@ -102,7 +102,7 @@ library
     Math.NumberTheory.Zeta.Riemann
     Math.NumberTheory.Zeta.Utils
   default-language: Haskell2010
-  ghc-options: -Wall -Widentities -Wcompat -Wno-deprecations
+  ghc-options: -Wall -Widentities -Wcompat -Wno-deprecations -O2
 
 test-suite arithmoi-tests
   build-depends:
@@ -168,7 +168,7 @@ test-suite arithmoi-tests
   main-is: Test.hs
   default-language: Haskell2010
   hs-source-dirs: test-suite
-  ghc-options: -Wall -Widentities -Wcompat -threaded
+  ghc-options: -Wall -Widentities -Wcompat -threaded -O2
 
 benchmark arithmoi-bench
   build-depends:
@@ -202,7 +202,7 @@ benchmark arithmoi-bench
   main-is: Bench.hs
   default-language: Haskell2010
   hs-source-dirs: benchmark
-  ghc-options: -Wall -Widentities -Wcompat
+  ghc-options: -Wall -Widentities -Wcompat -O2
 
 benchmark arithmoi-sequence-model
   build-depends:
@@ -215,4 +215,4 @@ benchmark arithmoi-sequence-model
   main-is: SequenceModel.hs
   default-language: Haskell2010
   hs-source-dirs: app
-  ghc-options: -Wall -Widentities -Wcompat
+  ghc-options: -Wall -Widentities -Wcompat -O2

--- a/benchmark/Math/NumberTheory/RecurrencesBench.hs
+++ b/benchmark/Math/NumberTheory/RecurrencesBench.hs
@@ -34,11 +34,11 @@ benchPartition n = bgroup "partition"
 benchSuite :: Benchmark
 benchSuite = bgroup "Recurrences"
   [ bgroup "Bilinear"
-    [ benchTriangle "binomial"  binomial  100
-    , benchTriangle "stirling1" stirling1 100
-    , benchTriangle "stirling2" stirling2 100
-    , benchTriangle "eulerian1" eulerian1 100
-    , benchTriangle "eulerian2" eulerian2 100
+    [ benchTriangle "binomial"  binomial  80
+    , benchTriangle "stirling1" stirling1 75
+    , benchTriangle "stirling2" stirling2 75
+    , benchTriangle "eulerian1" eulerian1 50
+    , benchTriangle "eulerian2" eulerian2 50
     ]
   , benchPartition 1000
   , bgroup "factorialFactors"


### PR DESCRIPTION
cabal generally installs packages with default -O1 optmization unless forced by a manual install - the only way to force it always to be installed with optimization is to add this to the cabal file.

Performance testing shows that the extra level of optimization gives a boost in execution speed of about two times, and for the prime counting function about two and a half times.